### PR TITLE
Replace dict of dicts with list of dicts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,18 +20,18 @@ project: w97
 
 experiment: five-site-test
 
-realisations: {
-  0: {
+realisations: [
+  {
     name: "trunk",
     trunk: True,
     share_branch: False,
   },
-  1: {
+  {
     name: "v3.0-YP-changes",
     trunk: False,
     share_branch: False,
   }
-}
+]
 
 modules: [
   intel-compiler/2021.1.1,


### PR DESCRIPTION
The `realisations` and `science_configurations` keys should be lists instead of key value pairs in the config file.

This change is a part of: https://github.com/CABLE-LSM/benchcab/pull/66