### PR TITLE
Remove project keyword from `config.yaml`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -15,8 +15,6 @@
 #
 # Strings can be given with or without double or single quotes.
 
-project: <project>
-
 experiment: five-site-test
 
 realisations:

--- a/config.yaml
+++ b/config.yaml
@@ -15,7 +15,7 @@
 #
 # Strings can be given with or without double or single quotes.
 
-project: w97
+project: <project>
 
 experiment: five-site-test
 


### PR DESCRIPTION
Setting `w97` in the project key may give the impression that `w97` is required to run benchcab. This replaces `w97` with an place holder value so that the user must specify their project explicitly.

Fixes #12