### PR TITLE
Minimal working example of bench_example before benchcab v4.0 

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -15,17 +15,12 @@
 #
 # Strings can be given with or without double or single quotes.
 
-experiment: five-site-test
-
 realisations:
-  - repo:
-      svn:
-        branch_path: trunk
   - repo:
       git:
         branch: main
         commit: 67a52dc5721f0da78ee7d61798c0e8a804dcaaeb  # Last commit compatible with benchcab for now. See issue #14
-
+  
 modules: [
   intel-compiler/2021.1.1,
   netcdf/4.7.4,

--- a/config.yaml
+++ b/config.yaml
@@ -26,6 +26,7 @@ realisations:
   - repo:
       git:
         branch: main
+        commit: 67a52dc5721f0da78ee7d61798c0e8a804dcaaeb  # Last commit compatible with benchcab for now. See issue #14
 
 modules: [
   intel-compiler/2021.1.1,


### PR DESCRIPTION
Fixes #14 and #16

Fixes various issues before release of benchcab.

Add commit id and comment so we remember to remove it once the issue is fixed.
Move the experiment keyword. 