### PR TITLE
Remove pinned commit hash from config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,7 +19,6 @@ realisations:
   - repo:
       git:
         branch: main
-        commit: 67a52dc5721f0da78ee7d61798c0e8a804dcaaeb  # Last commit compatible with benchcab for now. See issue #14
   
 modules: [
   intel-compiler/2021.1.1,


### PR DESCRIPTION
The version of CABLE was pinned due to developments to the build system (see https://github.com/CABLE-LSM/bench_example/issues/14). Benchcab now supports the CMake build system (see https://github.com/CABLE-LSM/benchcab/pull/278) and will fail to build the currently pinned version. This change unpins the CABLE version from the configuration file so that the latest version of CABLE (in `main`) can be tested.