### PR TITLE
Sync dev and main for benchcab `v4.0.3` compatibility

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,7 +19,6 @@ realisations:
   - repo:
       git:
         branch: main
-        commit: 67a52dc5721f0da78ee7d61798c0e8a804dcaaeb  # Last commit compatible with benchcab for now. See issue #14
   
 modules: [
   intel-compiler/2021.1.1,


### PR DESCRIPTION
The benchcab configuration file is currently not compatible with the latest version of benchcab (compatibility breaks at version [4.0.3](https://github.com/CABLE-LSM/benchcab/releases/tag/v4.0.3)) due to added support for CMake. This has been fixed in the `dev` branch:

- https://github.com/CABLE-LSM/bench_example/pull/20

This pull request syncs the `dev` and `main` branches. A new `v4.0.3` tag should then be pushed to the `main` branch.